### PR TITLE
可配置的访客跳跃权限

### DIFF
--- a/v1_20_1/src/main/java/cn/lunadeer/dominion/v1_20_1/events/player/Jump.java
+++ b/v1_20_1/src/main/java/cn/lunadeer/dominion/v1_20_1/events/player/Jump.java
@@ -1,0 +1,17 @@
+package cn.lunadeer.dominion.v1_20_1.events.player;
+
+import cn.lunadeer.dominion.api.dtos.flag.Flags;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import com.destroystokyo.paper.event.player.PlayerJumpEvent;
+
+import static cn.lunadeer.dominion.misc.Others.checkPrivilegeFlag;
+
+public class Jump implements Listener {
+    @EventHandler(priority = EventPriority.LOWEST)
+    public void handler(PlayerJumpEvent event) {
+        if (event.isCancelled()) return;
+        checkPrivilegeFlag(event.getPlayer().getLocation(), Flags.JUMP, event.getPlayer(), event);
+    }
+}


### PR DESCRIPTION
添加了一个跳跃权限，这需要对Dominion API也作出修改。该权限允许领地管理者调整玩家的权限，以便配置他们能否在领地中跳跃。
