### PR TITLE
fix: Downgraded the log level for command execution exceptions from severe to info

### DIFF
--- a/core/src/main/java/cn/lunadeer/dominion/utils/command/CommandManager.java
+++ b/core/src/main/java/cn/lunadeer/dominion/utils/command/CommandManager.java
@@ -165,7 +165,7 @@ public class CommandManager implements TabExecutor, Listener {
             cmd.run(commandSender, strings);
         } catch (Exception e) {
             commandSender.sendMessage(e.getMessage());
-            plugin.getLogger().severe(e.getMessage());
+            plugin.getLogger().info(e.getMessage());
         }
         return true;
     }


### PR DESCRIPTION
修复: 将命令执行异常的日志级别从severe降级为info
#208 
便于管理员通过日志排查错误