### PR TITLE
修复领地关闭火焰蔓延的情况下，方块会被烧没的bug

### DIFF
--- a/versions/v1_20_1/src/main/java/cn/lunadeer/dominion/v1_20_1/events/environment/FireSpread.java
+++ b/versions/v1_20_1/src/main/java/cn/lunadeer/dominion/v1_20_1/events/environment/FireSpread.java
@@ -5,6 +5,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockBurnEvent;
 import org.bukkit.event.block.BlockIgniteEvent;
 
 import static cn.lunadeer.dominion.misc.Others.checkEnvironmentFlag;
@@ -17,6 +18,12 @@ public class FireSpread implements Listener {
         if (player != null) {
             return;
         }
+        checkEnvironmentFlag(event.getBlock().getLocation(), Flags.FIRE_SPREAD, event);
+    }
+
+    @EventHandler(priority = EventPriority.LOWEST)
+    public void onBlockBurn(BlockBurnEvent event) {
+        if (event.isCancelled()) return;
         checkEnvironmentFlag(event.getBlock().getLocation(), Flags.FIRE_SPREAD, event);
     }
 }


### PR DESCRIPTION
领地在关闭火焰蔓延的情况下，玩家用打火石手动点火，虽然火焰不会被蔓延，但是方块会被烧没。
这样修改之后，就不会出现这个bug，可以正常点火，但火焰不会蔓延，而且方块也不会消失。