### PR TITLE
perf: cache dominion DTO in node to avoid repeated cache lookups

### DIFF
--- a/core/src/main/java/cn/lunadeer/dominion/cache/DominionNode.java
+++ b/core/src/main/java/cn/lunadeer/dominion/cache/DominionNode.java
@@ -1,8 +1,6 @@
 package cn.lunadeer.dominion.cache;
 
 import cn.lunadeer.dominion.api.dtos.DominionDTO;
-import cn.lunadeer.dominion.configuration.Language;
-import cn.lunadeer.dominion.misc.DominionException;
 import org.bukkit.Location;
 import org.jetbrains.annotations.NotNull;
 
@@ -14,29 +12,21 @@ import static cn.lunadeer.dominion.misc.Others.isInDominion;
 
 /**
  * The DominionNode class represents a node in the dominion tree structure.
- * <p>
- * DominionNode not store the dominion data, only the id of the dominion.
  */
 public class DominionNode {
-    private final Integer dominionId;
+    private final DominionDTO dominion;
     private CopyOnWriteArrayList<DominionNode> children = new CopyOnWriteArrayList<>();
 
-    public DominionNode(Integer dominionId) {
-        this.dominionId = dominionId;
+    public DominionNode(DominionDTO dominion) {
+        this.dominion = dominion;
     }
 
     /**
      * Gets the DominionDTO associated with this node.
-     * <p>
-     * This method will fetch the DominionDTO from the cache.
      *
      * @return the DominionDTO associated with this node
      */
     public @NotNull DominionDTO getDominion() {
-        DominionDTO dominion = CacheManager.instance.getDominion(dominionId);
-        if (dominion == null) {
-            throw new DominionException(Language.convertsText.unknownDominion, dominionId);
-        }
         return dominion;
     }
 
@@ -55,7 +45,7 @@ public class DominionNode {
      * @return the dominion ID
      */
     public Integer getDominionId() {
-        return dominionId;
+        return dominion.getId();
     }
 
     /**
@@ -89,7 +79,7 @@ public class DominionNode {
 
         if (children != null) {
             for (DominionDTO dominion : children) {
-                DominionNode node = new DominionNode(dominion.getId());
+                DominionNode node = new DominionNode(dominion);
                 node.children = buildTree(dominion.getId(), parentToChildrenMap);
                 dominionTree.add(node);
             }


### PR DESCRIPTION
坐标查领地时，getDominionNodeByLocation 线性扫描扇区里的每个 DominionNode，而每个节点原本只存 dominionId，于是每次 node.getDominion() 都要 CacheManager.getDominion(id) -> ConcurrentHashMap.get 查一次。导致循环中反复查 map。

## 解决如下：

让 DominionNode 直接持有 DominionDTO 引用，getDominion() 变成字段读，去掉每节点一次的 map 查询。

因为唯一的构造点 buildTree 本来就握着 DTO，建树不增加任何额外查询。