### PR TITLE
perf: skip player move handler when block position unchanged

### DIFF
--- a/versions/v1_20_1/src/main/java/cn/lunadeer/dominion/v1_20_1/events/player/Move.java
+++ b/versions/v1_20_1/src/main/java/cn/lunadeer/dominion/v1_20_1/events/player/Move.java
@@ -17,6 +17,10 @@ public class Move implements Listener {
     @EventHandler(priority = EventPriority.LOWEST)
     public void handler(PlayerMoveEvent event) {
         if (event.isCancelled()) return;
+        Location movedFrom = event.getFrom(), movedTo = event.getTo();
+        if (movedFrom.getBlockX() == movedTo.getBlockX()
+                && movedFrom.getBlockY() == movedTo.getBlockY()
+                && movedFrom.getBlockZ() == movedTo.getBlockZ()) return;
         Player player = event.getPlayer();
         DominionDTO dom = CacheManager.instance.getPlayerCurrentDominion(player);
         if (!checkPrivilegeFlag(player.getLocation(), Flags.MOVE, player, null)) {


### PR DESCRIPTION
玩家在同一方块格子内移动时直接跳过领地查询，只在跨方块时才处理