### PR TITLE
修复领地内死亡复活后飞行状态丢失和管理员在生存模式下无法在允许飞行的领地中飞行的bug

### DIFF
--- a/core/src/main/java/cn/lunadeer/dominion/handler/FlyGlowCheckHandler.java
+++ b/core/src/main/java/cn/lunadeer/dominion/handler/FlyGlowCheckHandler.java
@@ -13,14 +13,24 @@ import org.bukkit.World;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+import org.bukkit.event.player.PlayerRespawnEvent;
 import org.bukkit.event.player.PlayerToggleFlightEvent;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+
 import static cn.lunadeer.dominion.misc.Others.checkPrivilegeFlagSilence;
 
 public class FlyGlowCheckHandler implements Listener {
+
+    // 记录由 Dominion 主动开启飞行的玩家，用于区分 Dominion 和其他插件（Essentials/CMI）授予的飞行
+    private static final Set<UUID> dominionFlightPlayers = new HashSet<>();
 
     public FlyGlowCheckHandler(JavaPlugin plugin) {
         plugin.getServer().getPluginManager().registerEvents(this, plugin);
@@ -46,7 +56,7 @@ public class FlyGlowCheckHandler implements Listener {
         () -> {
             player.setGlowing(false);
         });
-        if (player.isOp() || player.getGameMode() == GameMode.CREATIVE || player.getGameMode() == GameMode.SPECTATOR) {
+        if (player.getGameMode() == GameMode.CREATIVE || player.getGameMode() == GameMode.SPECTATOR) {
             return;
         }
         handle(event.getPlayer(), event.getTo(), Flags.FLY, () -> allowFly(player), () -> disableFly(player));
@@ -57,12 +67,46 @@ public class FlyGlowCheckHandler implements Listener {
         DominionDTO dominion = event.getDominion();
         if (dominion != null) return;
         Player player = event.getPlayer();
-        if (player.isOp() || player.getGameMode() == GameMode.CREATIVE || player.getGameMode() == GameMode.SPECTATOR) {
+        if (player.getGameMode() == GameMode.CREATIVE || player.getGameMode() == GameMode.SPECTATOR) {
             return;
         }
-        disableFly(player);
+        // 领地被删除时强制关闭飞行，不受追踪来源限制
+        dominionFlightPlayers.remove(player.getUniqueId());
+        player.setAllowFlight(false);
         if (event.getPlayer().isFlying()) player.setFlying(false);
         player.setGlowing(false);
+    }
+
+    @EventHandler
+    public void onPlayerRespawn(PlayerRespawnEvent event) {
+        Player player = event.getPlayer();
+        if (player.getGameMode() == GameMode.CREATIVE || player.getGameMode() == GameMode.SPECTATOR) {
+            return;
+        }
+        // 死亡后原版重置飞行状态，清除追踪记录
+        dominionFlightPlayers.remove(player.getUniqueId());
+        // 清除缓存的领地ID，确保后续移动能正确触发边界事件
+        CacheManager.instance.resetPlayerCurrentDominionId(player);
+        // 在重生位置重新检查飞行状态
+        DominionDTO dominion = CacheManager.instance.getDominion(event.getRespawnLocation());
+        handle(player, dominion, Flags.FLY, () -> allowFly(player), () -> disableFly(player));
+    }
+
+    @EventHandler
+    public void onPlayerJoin(PlayerJoinEvent event) {
+        Player player = event.getPlayer();
+        if (player.getGameMode() == GameMode.CREATIVE || player.getGameMode() == GameMode.SPECTATOR) {
+            return;
+        }
+        // 玩家上线时重新检查飞行状态，防止在领地内下线后上线无法飞行
+        DominionDTO dominion = CacheManager.instance.getDominion(player.getLocation());
+        handle(player, dominion, Flags.FLY, () -> allowFly(player), () -> disableFly(player));
+    }
+
+    @EventHandler
+    public void onPlayerQuit(PlayerQuitEvent event) {
+        // 玩家退出时清理飞行追踪记录
+        dominionFlightPlayers.remove(event.getPlayer().getUniqueId());
     }
 
     private static void handle(@NotNull Player player,
@@ -92,20 +136,19 @@ public class FlyGlowCheckHandler implements Listener {
 
 
     private static void allowFly(Player player) {
-        for (String flyPN : Configuration.flyPermissionNodes) {
-            if (player.hasPermission(flyPN)) {
-                return;
-            }
+        // 记录由 Dominion 授予飞行的玩家，用于区分其他插件（Essentials/CMI）的飞行
+        if (!player.getAllowFlight()) {
+            dominionFlightPlayers.add(player.getUniqueId());
         }
         player.setAllowFlight(true);
     }
 
     private static void disableFly(Player player) {
-        for (String flyPN : Configuration.flyPermissionNodes) {
-            if (player.hasPermission(flyPN)) {
-                return;
-            }
+        // 只关闭由 Dominion 开启的飞行，不干涉其他插件授予的飞行
+        if (!dominionFlightPlayers.contains(player.getUniqueId())) {
+            return;
         }
+        dominionFlightPlayers.remove(player.getUniqueId());
         player.setAllowFlight(false);
         if (player.isFlying()) {
             player.setFlying(false);
@@ -115,7 +158,7 @@ public class FlyGlowCheckHandler implements Listener {
     @EventHandler
     public void onPlayerTryFly(PlayerToggleFlightEvent event) {
         Player player = event.getPlayer();
-        if (player.isOp() || player.getGameMode() == GameMode.CREATIVE || player.getGameMode() == GameMode.SPECTATOR) {
+        if (player.getGameMode() == GameMode.CREATIVE || player.getGameMode() == GameMode.SPECTATOR) {
             return;
         }
         DominionDTO dominion = CacheManager.instance.getDominion(event.getPlayer().getLocation());


### PR DESCRIPTION
  ## 问题
  1. **OP 生存模式在允许飞行的领地无法飞行**：领地已开启 FLY flag，普通玩家正常， OP 进入后按两下空格无法起飞
  2. **领地内死亡复活后飞行状态丢失**：在允许飞行的领地中死亡并复活，原版重置飞行状态后 无法恢复
  3. **上线后飞行状态丢失**：在允许飞行的领地中下线再上线，飞行状态丢失

  ## 根因
  1. 三个事件处理器通过 `player.isOp()` 提前 return，OP 完全跳过飞行管理流程
  2. `allowFly()` / `disableFly()` 检查 Essentials/CMI 的 bypass 权限节点，OP 默认拥有 所有权限 → return 空过 → 飞行操作从未执行
  3. `disableFly()` 一刀切关闭飞行，不区分飞行来源，干扰了外部插件的飞行
  4. 玩家死亡/重生/上下线不触发边界事件，飞行状态丢失后无恢复机制

  ## 修复

  1. **删除 `isOp()` 提前返回**：`onPlayerCrossBorder`、`onDominionDelete`、`onPlayerTryFly` 三处不再跳过 OP，OP 走正常权限链路（bypassLimit 在链路深处同样放行 OP）

  2. **飞行来源追踪机制**：新增 `Set<UUID>` 记录由 Dominion 主动开启飞行的玩家
     - `allowFly()`：玩家原本不能飞时记录为 Dominion 来源，再授予飞行；原本已能飞 （如 Essentials 给的）则不记录
     - `disableFly()`：仅关闭由 Dominion 开启的飞行，不干涉外部插件授予的飞行

  3. **新增 `onPlayerRespawn`**：死亡后清除追踪记录和领地缓存，在重生位置重新检查飞行

  4. **新增 `onPlayerJoin`**：上线时重新检查飞行状态

  5. **新增 `onPlayerQuit`**：清理飞行追踪记录

  6. **`onDominionDelete`**：领地被删除时强制关闭飞行，不受追踪来源限制

  ## 兼容性

  - 普通玩家行为完全不变
  - 创造/旁观模式不受影响
  - Essentials/CMI `/fly`：在领地外授予的飞行进入允许飞行的领地后离开 → 保留； 进入禁飞领地 → 保留（Dominion 不干涉非自己开启的飞行）
  - `flyPermissionNodes` 配置项不再被 `allowFly`/`disableFly` 使用，可后续清理