### PR TITLE
fix: 修复盆栽破坏权限检查逻辑

### DIFF
--- a/versions/v1_20_1/src/main/java/cn/lunadeer/dominion/v1_20_1/events/player/Break/FlowerPot.java
+++ b/versions/v1_20_1/src/main/java/cn/lunadeer/dominion/v1_20_1/events/player/Break/FlowerPot.java
@@ -16,7 +16,10 @@ public class FlowerPot implements Listener {
         if (event.isCancelled()) return;
         if (event.getAction() != Action.RIGHT_CLICK_BLOCK) return;
         if (event.getClickedBlock() == null) return;
-        if (event.getClickedBlock().getType() != Material.FLOWER_POT) return;
+        Material blockType = event.getClickedBlock().getType();
+        if (!Tag.FLOWER_POTS.isTagged(blockType) || blockType == Material.FLOWER_POT) {
+            return;
+        }
         checkPrivilegeFlag(event.getClickedBlock().getLocation(), Flags.BREAK_BLOCK, event.getPlayer(), event);
     }
 }


### PR DESCRIPTION
目前插件在检查花盆权限时仅判断了 `Material.FLOWER_POT`。这导致当玩家尝试从已经插有植物的盆栽中移除植物时，领地权限检查会失效，同时错误的使用 BREAK_BLOCK 权限 拦截了往空花盆插植物的检查。
本 PR 补充了所有盆栽植物的权限检查，并移除了空花盆在此处的检查，对空花盆插入花的检查已经存在于 [Place/FlowerPot.java](https://github.com/LunaDeerMC/Dominion/blob/master/versions/v1_20_1/src/main/java/cn/lunadeer/dominion/v1_20_1/events/player/Place/FlowerPot.java) 